### PR TITLE
allennlp requires specific pytorch-transformers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nltk
-allennlp
+allennlp==0.8.5
 numpy
 ipykernel
-pytorch-transformers
+pytorch-transformers==1.1.0


### PR DESCRIPTION
allennlp:latest (0.8.5) requires pytorch-transformers==1.1.0